### PR TITLE
cli-features

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -13,6 +13,9 @@ In order to build an experiment, you can execute the follwing command:
 thunder build /path/to/config /path/to/experiment
 ```
 It will create a folder with built configs in it.  
+If `/path/to/experiment` already exists, thunder raises error. 
+In order to overwrite existing directory use `--overwrite` / `-o` flags.
+
 ### Overriding config entries
 While conducting experiments one can find themselves in constant need of
 changing significant number of parameters. But it is not convenient to always do
@@ -29,7 +32,6 @@ You can override it using `-u` flag:
 thunder build /path/to/config /path/to/experiment -u batch_size=2 -u lr=0.001 
 ```
 `batch_size` and `lr` will be assigned 2 and 0.001 respectively.
-
 ## Running an experiment
 You can run built experiment by executing the next command:
 ```bash
@@ -51,7 +53,8 @@ The command shown above will run SLURM job with 4 CPUs and 100G of RAM.
 
 ### Predefined run configs
 You can predefine run configs to avoid reentering the same flags.
-Create `.config/thunder/backends.yml` in you home directory. 
+Create `~/.config/thunder/backends.yml` (you can run `thunder show` in your terminal, 
+required path will be at the title of the table) in you home directory. 
 Now you can specify config name and its parameters:
 ```yaml
 run_config_name:
@@ -64,12 +67,51 @@ run_config_name:
 ```
 In order to run an experiment with predefined parameters, 
 use `--backend` flag as in previous section:
+
 ```bash
 thunder run /path/to/experiment/ --backend run_config_name
 ```
 You can overwrite parameters if you want to (e.g. 8 CPUs instead of 4):
 ```bash
 thunder run /path/to/experiment/ --backend run_config_name -c 8
+```
+
+### Add, Set, List, Remove 
+`thunder` CLI provides its users with built-in tools for managing their [backends](./#backend).
+
+| Command                  | Description                                                       |
+|--------------------------|-------------------------------------------------------------------|
+| `thunder backend add`    | Add run config to the list of available configs.                  |
+| `thunder backend list`   | Show parameters of specified backend(s).                          |
+| `thunder backend remove` | Delete backend from list.                                         |
+| `thunder backend set`     | Set specified backend from list of available backends as default. |
+
+#### Examples
+##### add
+
+```bash
+thunder backend add run_config_name backend=slurm ram=100 cpu=4 gpu=1 partition=partition_name
+```
+If specified name already exists, you can use `--force` flag in order to overwrite it.  
+
+##### set
+```bash
+thunder backend set SOMENAME
+thunder backend list
+```
+
+##### list 
+```bash
+thunder backend list NAME1 NAME2
+*shows backends with specified names*
+
+thunder backend list
+*shows all backends*
+```
+
+##### remove
+```bash
+thunder backend remove SOMENAME
 ```
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,6 @@ import os
 import re
 import shutil
 from contextlib import contextmanager
-from functools import wraps
 from pathlib import Path
 
 import pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
-from lazycon import Config
+from lazycon import Config, load as read_config
 from typer.testing import CliRunner
 
 from thunder.cli.backend import BACKENDS_CONFIG_PATH
@@ -79,6 +79,20 @@ def test_build_cleanup(temp_dir):
     result = invoke('build', config, experiment)
     assert result.exit_code != 0
     assert not experiment.exists()
+
+
+def test_build_overwrite(temp_dir):
+    experiment = temp_dir / 'exp'
+    experiment.mkdir()
+    (experiment / 'experiment.config').write_text('a = 1')
+
+    config = temp_dir / 'new.config'
+    config.write_text('b = 2')
+
+    result = invoke('build', config, experiment, "--overwrite")
+    assert result.exit_code == 0
+    assert not hasattr(read_config(experiment / "experiment.config"), "a")
+    assert read_config(experiment / "experiment.config").b == 2
 
 
 @pytest.mark.timeout(30)

--- a/thunder/backend/__init__.py
+++ b/thunder/backend/__init__.py
@@ -1,3 +1,3 @@
 from .cli import Cli
-from .interface import Backend, BackendConfig, BackendEntryConfig, backends
+from .interface import Backend, BackendConfig, BackendEntryConfig, MetaEntry, backends
 from .slurm import Slurm

--- a/thunder/backend/interface.py
+++ b/thunder/backend/interface.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Sequence, Type
+from typing import Optional, Sequence, Type, Dict, Union
 
 from pydantic import BaseModel, Extra, validator
 
@@ -36,4 +36,4 @@ class BackendEntryConfig(BaseModel):
         extra = Extra.ignore
 
 
-backends = {}
+backends: Dict[str, Backend] = {}

--- a/thunder/backend/interface.py
+++ b/thunder/backend/interface.py
@@ -36,4 +36,8 @@ class BackendEntryConfig(BaseModel):
         extra = Extra.ignore
 
 
+class MetaEntry(BaseModel):
+    default: str
+
+
 backends: Dict[str, Backend] = {}

--- a/thunder/backend/interface.py
+++ b/thunder/backend/interface.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Sequence, Type, Dict, Union
+from typing import Optional, Sequence, Type, Dict
 
 from pydantic import BaseModel, Extra, validator
 

--- a/thunder/backend/interface.py
+++ b/thunder/backend/interface.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Sequence, Type, Dict
+from typing import Dict, Optional, Sequence, Type
 
 from pydantic import BaseModel, Extra, validator
 

--- a/thunder/backend/slurm.py
+++ b/thunder/backend/slurm.py
@@ -58,6 +58,12 @@ class Slurm(Backend):
             help='Limit the number of jobs that are simultaneously running during the experiment',
         )] = None
 
+        @validator("ram")
+        def val_ram(cls, v):
+            if v is None:
+                return
+            return v if v[-1].isalpha() else f"{v}G"
+
         @validator('time')
         def val_time(cls, v):
             if v is None:

--- a/thunder/cli/backend.py
+++ b/thunder/cli/backend.py
@@ -9,8 +9,9 @@ from typer.core import TyperCommand
 from typer.main import get_click_param
 from typer.models import ParamMeta
 
-from .app import app
 from ..backend import BackendEntryConfig, backends
+from .app import app
+
 
 BACKENDS_CONFIG_PATH = Path(typer.get_app_dir(app.info.name)) / 'backends.yml'
 
@@ -113,6 +114,7 @@ def populate(backend_name):
 def load_backend_configs() -> dict:
     path = BACKENDS_CONFIG_PATH
     if not path.exists():
+        # print(path, flush=True)
         return {}
 
     with path.open('r') as file:

--- a/thunder/cli/backend_cli.py
+++ b/thunder/cli/backend_cli.py
@@ -1,9 +1,10 @@
-from typing import Annotated, List
+from typing import List
 
 import yaml
 from rich.console import Console
 from rich.table import Table
 from typer import Abort, Argument, Option, Typer
+from typing_extensions import Annotated
 
 from ..backend import MetaEntry
 from .backend import BACKENDS_CONFIG_PATH, BackendEntryConfig, load_backend_configs

--- a/thunder/cli/backend_cli.py
+++ b/thunder/cli/backend_cli.py
@@ -1,0 +1,90 @@
+from typing import Annotated, List
+
+import yaml
+from rich.console import Console
+from rich.table import Table
+from typer import Abort, Argument, Option, Typer
+
+from .backend import BACKENDS_CONFIG_PATH, BackendEntryConfig, load_backend_configs
+from ..backend import MetaEntry
+
+BackendNameArg = Annotated[str, Argument(
+    show_default=False, help="Name of the config from your list of backends."
+)]
+BackendNamesArg = Annotated[List[str], Argument(
+    show_default=False, help="Names of the configs from your list of backends."
+)]
+BackendParamsArg = Annotated[List[str], Argument(
+    show_default=False, help="Parameters of added run config.")]
+ForceAddArg = Annotated[bool, Option(
+    "--force", "-f", help="Forces overwriting of the same backend in .yml file."
+)]
+
+console = Console()
+backend_app = Typer(name="backend", help="Commands for managing your backends.")
+
+
+@backend_app.command(name="set")
+def _set(name: BackendNameArg):
+    """ Set specified backend from list of available backends as default. """
+    local = load_backend_configs()
+    if name not in local:
+        console.print(f"Specified backend `{name} is not among "
+                      f"available configs: {sorted(local)}`")
+        raise Abort(1)
+
+    local["meta"] = MetaEntry.parse_obj({"default": name})
+    with BACKENDS_CONFIG_PATH.open("w") as stream:
+        yaml.safe_dump({k: v.dict() for k, v in local.items()}, stream)
+
+
+@backend_app.command()
+def add(name: BackendNameArg, params: BackendParamsArg, force: ForceAddArg = False):
+    """ Add run config to the list of available configs. """
+    local = load_backend_configs()
+    if name in local and not force:
+        console.print(f"Backend `{name}` is already present in {str(BACKENDS_CONFIG_PATH)}. "
+                      f"If you want it to be overwritten, add --force flag.")
+        raise Abort(1)
+
+    kwargs = dict(map(lambda p: p.split("="), params))
+    config = {"backend": kwargs.pop("backend", "cli"), "config": kwargs}
+
+    local.update({name: BackendEntryConfig.parse_obj(config)})
+    with BACKENDS_CONFIG_PATH.open("w") as stream:
+        yaml.safe_dump({k: v.dict() for k, v in local.items()}, stream)
+
+
+@backend_app.command()
+def remove(name: BackendNameArg):
+    """ Delete backend from list. """
+    local = load_backend_configs()
+    if name not in local:
+        console.print(f"Backend `{name}` is not among your configs.")
+        raise Abort(1)
+
+    local.pop(name)
+    with BACKENDS_CONFIG_PATH.open("w") as stream:
+        yaml.safe_dump({k: v.dict() for k, v in local.items()}, stream)
+
+
+@backend_app.command(name="list")
+def _list(names: BackendNamesArg = None):
+    """ Show parameters of specified backend(s). """
+    local = load_backend_configs()
+
+    table = Table("Name", "Backend", "Parameters",
+                  title=f"Configs at {str(BACKENDS_CONFIG_PATH.resolve())}")
+
+    extra = set(names) - set(local)
+    if extra:
+        console.print("These names are not among your configs:", extra)
+
+    for name in sorted(set(names if names else local) - extra.union({"meta"})):
+        entry = local[name].dict()
+        table.add_row(*map(str, [name, entry.get("backend", None), entry.get("config", None)]))
+
+    console.print(table)
+
+    if "meta" in local:
+        console.print(f"[italic green]Default is [/italic green]{local['meta'].default}")

--- a/thunder/cli/backend_cli.py
+++ b/thunder/cli/backend_cli.py
@@ -5,8 +5,9 @@ from rich.console import Console
 from rich.table import Table
 from typer import Abort, Argument, Option, Typer
 
-from .backend import BACKENDS_CONFIG_PATH, BackendEntryConfig, load_backend_configs
 from ..backend import MetaEntry
+from .backend import BACKENDS_CONFIG_PATH, BackendEntryConfig, load_backend_configs
+
 
 BackendNameArg = Annotated[str, Argument(
     show_default=False, help="Name of the config from your list of backends."

--- a/thunder/cli/entrypoint.py
+++ b/thunder/cli/entrypoint.py
@@ -1,9 +1,11 @@
 from . import main as _main  # noqa
+from .backend_cli import backend_app
 from .main import app
 from .wandb import wand_app
 
 
 app.add_typer(wand_app)
+app.add_typer(backend_app)
 
 
 def main():

--- a/thunder/cli/main.py
+++ b/thunder/cli/main.py
@@ -8,8 +8,6 @@ import yaml
 from deli import load, save
 from lazycon import Config
 from lightning import LightningModule, Trainer
-from pydantic_yaml import to_yaml_str
-from toolz import valmap
 from typer import Abort, Argument, Option
 from typing_extensions import Annotated
 
@@ -222,7 +220,7 @@ def show(names: List[BackendNameArg] = None):
         print(f"{name}:", local[name], flush=True)
 
     if "_default" in local:
-        print(f"Default config:", local["_default"], flush=True)
+        print("Default config:", local["_default"], flush=True)
 
 
 def load_nodes(experiment: Path):

--- a/thunder/cli/main.py
+++ b/thunder/cli/main.py
@@ -23,6 +23,7 @@ ConfArg = Annotated[Path, Argument(show_default=False, help='The config from whi
 UpdArg = Annotated[List[str], Option(
     ..., '--update', '-u', help='Overwrite specific config entries', show_default=False
 )]
+OverwriteArg = Annotated[bool, Option("--overwrite", "-o", help="If specified, overwrites target directory")]
 NamesArg = Annotated[Optional[str], Option(..., help='Names of sub-experiments to start')]
 
 
@@ -94,6 +95,7 @@ def start(
 def build(
         config: ConfArg,
         experiment: ExpArg,
+        overwrite: OverwriteArg = False,
         update: UpdArg = (),
 ):
     """ Build an experiment """
@@ -105,8 +107,11 @@ def build(
 
     experiment = Path(experiment)
     if experiment.exists():
-        print(f'Cannot create an experiment in the folder "{experiment}", it already exists')
-        raise Abort(1)
+        if overwrite:
+            shutil.rmtree(experiment)
+        else:
+            print(f'Cannot create an experiment in the folder "{experiment}", it already exists')
+            raise Abort(1)
 
     build_exp(Config.load(config), experiment, updates)
 


### PR DESCRIPTION
# Features
- `--overwrite` flag for `thunder build` for overwriting target directory (#47).  
### `thunder backend` scope of CLI commands.
- `thunder backend set` can set default backend for `run` (#40).
- `thunder backend add` adds configs to backends.yml
- `thunder backend list` shows available configs
- `thunder backend remove` removes specified config
# Fixes
- -r flage for slurm now uses GBs by default (#39)