### PR TITLE
`MetricMonitor` api changes and fixes

### DIFF
--- a/docs/callbacks/index.md
+++ b/docs/callbacks/index.md
@@ -6,6 +6,6 @@ For extra information see [this](https://lightning.ai/docs/pytorch/stable/extens
 ## Thunder Callbacks
 | Name                                   | Description                                           |
 |----------------------------------------|-------------------------------------------------------|
-| [MetricLogger](./metric_logger)        | Computes metrics and logs them                        |
+| [MetricLogger](./metric_monitor)        | Computes metrics and logs them                        |
 | [TimeProfiler](./time_profiler)        | Logs the time of each LightningModule's step          |
 | [FailOnInterrupt](./fail_on_interrupt) | Forces lightning Trainer to fail on KeyboardInterrupt |

--- a/docs/callbacks/index.md
+++ b/docs/callbacks/index.md
@@ -6,6 +6,6 @@ For extra information see [this](https://lightning.ai/docs/pytorch/stable/extens
 ## Thunder Callbacks
 | Name                                   | Description                                           |
 |----------------------------------------|-------------------------------------------------------|
-| [MetricLogger](./metric_monitor)        | Computes metrics and logs them                        |
+| [MetricMonitor](./metric_monitor)        | Computes metrics and logs them                        |
 | [TimeProfiler](./time_profiler)        | Logs the time of each LightningModule's step          |
 | [FailOnInterrupt](./fail_on_interrupt) | Forces lightning Trainer to fail on KeyboardInterrupt |

--- a/docs/callbacks/metric_monitor.md
+++ b/docs/callbacks/metric_monitor.md
@@ -1,4 +1,4 @@
-# MetricLogger
+# MetricMonitor
 This callback takes on computation and aggregation of the specified metrics.  
 
 ## Usage
@@ -19,7 +19,7 @@ At the end of epoch they are averaged and sent to logger.
 Metrics are assumed to be received as tuple `(X, Y)`, where
 **X** - batch of predictions, **Y** - batch of targets. 
 Further process of computation depends on whether `Group` or `Single`
-metrics are used. Also, there is no difference for MetricLogger between 
+metrics are used. Also, there is no difference for MetricMonitor between 
 `(X, Y)` and `((X,), (Y,))`.  
 If your model has multiple outputs or requires multiple targets
 (e.g. neural network with 2 heads.), the output is expected to be
@@ -61,7 +61,7 @@ from sklearn.metrics import accuracy_score
 
 trainer = Trainer(callbacks=[MetricMonitor(single_metrics={"accuracy": accuracy_score})])
 ```
-MetricLogger will log mean values by default. But you can add custom aggregations as well.
+MetricMonitor will log mean values by default. But you can add custom aggregations as well.
 #### Custom aggregations
 Let see what can be done if we want to log `std` of metrics as well as mean values.
 
@@ -95,7 +95,7 @@ aggregate_fn = [np.std, np.median]
 aggregate_fn = [np.std, "median", "max", "min"]
 aggregate_fn = {"zero": lambda x: x[0]}
 ```
-MetricLogger can accept `str` or `List[str]` as `aggregate_fn`, 
+MetricMonitor can accept `str` or `List[str]` as `aggregate_fn`, 
 in this format it supports the following metrics:
 
 | Name     | Function    |  
@@ -132,7 +132,7 @@ flag. Being set to `True` it forces the callback to store table of metrics in th
 | ...          | ...        | ...         |
 | batch_idxn_m | some_value | some_value  |
 
-For each set (e.g. `val`, `test`) and each `dataloader_idx`, MetricLogger stores separate table.  
+For each set (e.g. `val`, `test`) and each `dataloader_idx`, MetricMonitor stores separate table.  
 By default aforementioned tables are saved to `default_root_dir` of lightning's Trainer, in the format of
 `set_name/dataloader_idx.csv` (e.g. `val/dataloader_0.csv`).  
 If loggers you use have method `log_table` (e.g. `WandbLogger`), 
@@ -154,7 +154,7 @@ If all batches consist of single object, then `"_{i}"` is removed.
 
 
 ## Reference
-::: thunder.callbacks.metric_monitor.MetricLogger
+::: thunder.callbacks.metric_monitor.MetricMonitor
     handler: python
     options:
       members:

--- a/docs/callbacks/metric_monitor.md
+++ b/docs/callbacks/metric_monitor.md
@@ -35,11 +35,12 @@ element of batch `X1`.
 ### Group metrics
 Group metrics are computed on the entire dataset.
 For example, you want to compute classification accuracy on MNIST.
+
 ```python
-from thunder.callbacks import MetricLogger
+from thunder.callbacks import MetricMonitor
 from sklearn.metrics import accuracy_score
 
-trainer = Trainer(callbacks=[MetricLogger(group_metrics={"accuracy": accuracy_score})])
+trainer = Trainer(callbacks=[MetricMonitor(group_metrics={"accuracy": accuracy_score})])
 ```
 
 If you use any loggers (e.g. `Tensorboard` or `WandB`), `accuracy` will appear in them as follows:  
@@ -53,26 +54,28 @@ covered in **Preprocessing** part in **Single Metrics** paragraph.
 Single metrics are computed on each object separately and only then aggregated.
 It is a common use case for tasks like segmentation or object detection.
 #### Simple use case
+
 ```python
-from thunder.callbacks import MetricLogger
+from thunder.callbacks import MetricMonitor
 from sklearn.metrics import accuracy_score
 
-trainer = Trainer(callbacks=[MetricLogger(single_metrics={"accuracy": accuracy_score})])
+trainer = Trainer(callbacks=[MetricMonitor(single_metrics={"accuracy": accuracy_score})])
 ```
 MetricLogger will log mean values by default. But you can add custom aggregations as well.
 #### Custom aggregations
 Let see what can be done if we want to log `std` of metrics as well as mean values.
+
 ```python
 import numpy as np
-from thunder.callbacks import MetricLogger
+from thunder.callbacks import MetricMonitor
 from sklearn.metrics import accuracy_score
 
 aggregate_fn = np.std
 
-metric_logger = MetricLogger(single_metrics={"accuracy": accuracy_score},
-                             aggregate_fn=aggregate_fn) 
+metric_monitor = MetricMonitor(single_metrics={"accuracy": accuracy_score},
+                              aggregate_fn=aggregate_fn)
 
-trainer = Trainer(callbacks=[metric_logger])
+trainer = Trainer(callbacks=[metric_monitor])
 ```
 The mean values appear in loggers with no additional keys. 
 MetricCallback will try to infer the name of an aggregating function
@@ -134,7 +137,7 @@ By default aforementioned tables are saved to `default_root_dir` of lightning's 
 `set_name/dataloader_idx.csv` (e.g. `val/dataloader_0.csv`).  
 If loggers you use have method `log_table` (e.g. `WandbLogger`), 
 then this method will receive key and each table in the format of `pd.DataFrame`.  
-Code from `metric_logger.py`:
+Code from `metric_monitor.py`:
 ```python
 logger.log_table(f"{key}/dataloader_{dataloader_idx}", dataframe=dataframe)
 ```
@@ -151,7 +154,7 @@ If all batches consist of single object, then `"_{i}"` is removed.
 
 
 ## Reference
-::: thunder.callbacks.metric_logger.MetricLogger
+::: thunder.callbacks.metric_monitor.MetricLogger
     handler: python
     options:
       members:

--- a/docs/callbacks/metric_monitor.md
+++ b/docs/callbacks/metric_monitor.md
@@ -48,7 +48,16 @@ If you use any loggers (e.g. `Tensorboard` or `WandB`), `accuracy` will appear i
 `test/accuracy` - test metrics.
 
 You can also use preprocessing functions as keys of the dictionary. It is 
-covered in **Preprocessing** part in **Single Metrics** paragraph.
+covered in **Preprocessing** part in **Single Metrics** paragraph. Here is simple example
+```python
+from sklearn.metrics import accuracy_score, recall_score
+# y is binary label
+# x is e.g. a binary tensor and we want to know if there is any true value in it.
+threshold = lambda y, x: (y, x.any())
+
+group_metrics = {threshold: [accuracy_score, recall_score]}
+```
+Despite group metrics being calculated on collections of entries, preprocessing is applied individually.
 
 ### Single metrics
 Single metrics are computed on each object separately and only then aggregated.
@@ -113,13 +122,16 @@ from sklearn.metrics import accuracy_score, recall_score
 
 threshold = lambda y, x: (y > 0.5, x)
 
-single_metrics = {threshold: [accuracy_score, recall_score()]} 
+single_metrics = {threshold: [accuracy_score, recall_score]} 
 # or
 single_metrics = {threshold: {"acc": accuracy_score, "rec": recall_score}}
 # or
 single_metrics = {threshold: recall_score}
 ...
 ```
+In the example above, `accuracy_score` and `recall_score` are computed on each case separately 
+(e.g. like in semantic segmentation task). 
+Preprocessing functions are applied on each entry separately in both `single_megtrics` and `group_metrics`.
 #### Individual Metrics
 While computing `single_metrics`, one may appear in need of knowledge of metrics on each case.
 For this particular problem, the callback provides its users with `log_individual_metrics`

--- a/docs/examples/mnist.md
+++ b/docs/examples/mnist.md
@@ -6,7 +6,7 @@ from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.loggers import WandbLogger
 from sklearn.metrics import accuracy_score
 from thunder import ThunderModule
-from thunder.callbacks import MetricLogger
+from thunder.callbacks import MetricMonitor
 from thunder.placeholders import ExpName, GroupName
 from torch import nn
 from torch.utils.data import DataLoader
@@ -14,7 +14,6 @@ from torchvision import transforms
 from torchvision.datasets import MNIST
 
 BATCH_SIZE = 256
-
 
 train_ds = MNIST(".", train=True, download=True, transform=transforms.ToTensor())
 val_ds = MNIST(".", train=False, download=True, transform=transforms.ToTensor())
@@ -29,7 +28,8 @@ module = ThunderModule(
 
 # Initialize a trainer
 trainer = Trainer(
-    callbacks=[ModelCheckpoint(save_last=True), MetricLogger(group_metrics={lambda y, x: (np.argmax(y), x): accuracy_score})],
+    callbacks=[ModelCheckpoint(save_last=True),
+               MetricMonitor(group_metrics={lambda y, x: (np.argmax(y), x): accuracy_score})],
     accelerator="auto",
     devices=1,
     max_epochs=100,

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,6 @@ $ thunder build base.config /path/to/some/folder
 
 ## Core Features
 - ### [ThunderModule](./core/thunder_module)
-- ### [MetricLogger](./callbacks/metric_monitor)
+- ### [MetricMonitor](./callbacks/metric_monitor)
 - ### [Experiment configs](./configs)
 - ### [CLI & Integrations with WandB](./cli)

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,6 @@ $ thunder build base.config /path/to/some/folder
 
 ## Core Features
 - ### [ThunderModule](./core/thunder_module)
-- ### [MetricLogger](./callbacks/metric_logger)
+- ### [MetricLogger](./callbacks/metric_monitor)
 - ### [Experiment configs](./configs)
 - ### [CLI & Integrations with WandB](./cli)

--- a/tests/callbacks/test_seed_everything.py
+++ b/tests/callbacks/test_seed_everything.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from thunder.callbacks import SeedEverything
 
 

--- a/thunder/callbacks/__init__.py
+++ b/thunder/callbacks/__init__.py
@@ -1,4 +1,4 @@
 from .fail_on_interrupt import FailOnInterrupt
 from .inference_runner import InferenceRunner
-from .metric_logger import MetricLogger
+from .metric_monitor import MetricMonitor
 from .time_profiler import TimeProfiler

--- a/thunder/callbacks/__init__.py
+++ b/thunder/callbacks/__init__.py
@@ -1,4 +1,5 @@
 from .fail_on_interrupt import FailOnInterrupt
 from .inference_runner import InferenceRunner
 from .metric_monitor import MetricMonitor
+from .seed_everything import SeedEverything
 from .time_profiler import TimeProfiler

--- a/thunder/callbacks/metric_logger.py
+++ b/thunder/callbacks/metric_logger.py
@@ -190,7 +190,7 @@ class MetricLogger(Callback):
 
         for dataloader_idx, all_predictions in self._all_predictions.items():
             loader_postfix = f"/{dataloader_idx}" if len(self._all_predictions) > 1 else ""
-            predictions, targets = zip(*all_predictions)
+            targets, predictions = zip(*all_predictions)
             for preprocess, metrics_names in self.group_preprocess.items():
                 preprocessed = preprocess(targets, predictions)
                 for name in metrics_names:

--- a/thunder/callbacks/metric_logger.py
+++ b/thunder/callbacks/metric_logger.py
@@ -190,7 +190,7 @@ class MetricLogger(Callback):
 
         for dataloader_idx, all_predictions in self._all_predictions.items():
             loader_postfix = f"/{dataloader_idx}" if len(self._all_predictions) > 1 else ""
-            predictions, targets = map(np.asarray, zip(*all_predictions))
+            predictions, targets = zip(*all_predictions)
             for preprocess, metrics_names in self.group_preprocess.items():
                 preprocessed = preprocess(targets, predictions)
                 for name in metrics_names:

--- a/thunder/callbacks/metric_monitor.py
+++ b/thunder/callbacks/metric_monitor.py
@@ -16,7 +16,7 @@ from ..torch.utils import to_np
 from ..utils import collect, squeeze_first
 
 
-class MetricLogger(Callback):
+class MetricMonitor(Callback):
     def __init__(
             self,
             single_metrics: Dict = None,
@@ -62,7 +62,7 @@ class MetricLogger(Callback):
         self.group_preprocess = group_preprocess
         self._train_losses = []
         self._single_metric_values = defaultdict(lambda: {name: {} for name in single_metrics})
-        self._all_predictions = defaultdict(list)
+        self._all_predictions = defaultdict(lambda: {prep: [] for prep in self.group_preprocess})
         self._default_aggregators = {"min": np.min, "max": np.max, "median": np.median, "std": np.std}
 
         self.aggregate_fn = {"": np.mean}
@@ -173,9 +173,12 @@ class MetricLogger(Callback):
         outputs = (ys, xs)
 
         if self.group_metrics:
-            self._all_predictions[dataloader_idx].extend(zip(*outputs))
+            for preprocess in self.group_preprocess.keys():
+                self._all_predictions[dataloader_idx][preprocess].extend(
+                    preprocess(*args) for args in zip_equal(*outputs)
+                )
 
-        for i, (target, pred) in enumerate(zip(*outputs)):
+        for i, (target, pred) in enumerate(zip_equal(*outputs)):
             object_idx = f"{batch_idx}_{i}"
             for preprocess, metrics_names in self.single_preprocess.items():
                 preprocessed = preprocess(target, pred)
@@ -190,9 +193,8 @@ class MetricLogger(Callback):
 
         for dataloader_idx, all_predictions in self._all_predictions.items():
             loader_postfix = f"/{dataloader_idx}" if len(self._all_predictions) > 1 else ""
-            targets, predictions = zip(*all_predictions)
             for preprocess, metrics_names in self.group_preprocess.items():
-                preprocessed = preprocess(targets, predictions)
+                preprocessed = _recombine_batch(all_predictions[preprocess])
                 for name in metrics_names:
                     group_metric_values[f"{name}{loader_postfix}"] = self.group_metrics[name](*preprocessed)
 
@@ -240,7 +242,7 @@ def _get_func_name(function: Callable) -> str:
             return function.__name__
         return function.__class__.__name__
 
-    raise ValueError(f"You must pass a callable object, got f{type(function)}")
+    raise ValueError(f"You must pass a callable object, got {type(function)}")
 
 
 def _identity(*args):

--- a/thunder/callbacks/metric_monitor.py
+++ b/thunder/callbacks/metric_monitor.py
@@ -196,7 +196,9 @@ class MetricMonitor(Callback):
             for preprocess, metrics_names in self.group_preprocess.items():
                 preprocessed = _recombine_batch(all_predictions[preprocess])
                 for name in metrics_names:
-                    group_metric_values[f"{name}{loader_postfix}"] = self.group_metrics[name](*preprocessed)
+                    group_metric_values[f"{name}{loader_postfix}"] = self.group_metrics[name](
+                        *map(np.asarray, preprocessed)
+                    )
 
         single_metric_values = {}
         for fn_name, fn in self.aggregate_fn.items():

--- a/thunder/callbacks/seed_everything.py
+++ b/thunder/callbacks/seed_everything.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from lightning import Callback, seed_everything
 


### PR DESCRIPTION
# Changes
- Renamed `MetricLogger` as `MetricMonitor`.
# Fixes
- Preprocessing now works individually (#68)