### PR TITLE
Fix `last_checkpoint`

### DIFF
--- a/tests/torch/test_utils.py
+++ b/tests/torch/test_utils.py
@@ -90,8 +90,16 @@ def test_last_checkpoint(temp_dir):
 
     assert last_checkpoint(temp_dir / "two_checkpoints") == temp_dir / "two_checkpoints" / "second" / "model1.ckpt"
 
+    symlink_path = Path(temp_dir / "two_checkpoints" / "first" / "symlink")
+    symlink_path.symlink_to(temp_dir / "two_checkpoints" / "second" / "model1.ckpt")
+
+    assert (
+        last_checkpoint(temp_dir / "two_checkpoints" / "first")
+        == temp_dir / "two_checkpoints" / "second" / "model1.ckpt"
+    )
+
     _create_file(temp_dir / "zero_checkpoints" / "first" / "not_ckpt")
     time.sleep(0.1)
     _create_file(temp_dir / "zero_checkpoints" / "second" / "not_ckpt")
 
-    assert last_checkpoint(temp_dir / "zero_checkpoints") is None
+    assert last_checkpoint(temp_dir / "zero_checkpoints") == "last"

--- a/tests/torch/test_utils.py
+++ b/tests/torch/test_utils.py
@@ -94,4 +94,4 @@ def test_last_checkpoint(temp_dir):
     time.sleep(0.1)
     _create_file(temp_dir / "zero_checkpoints" / "second" / "not_ckpt")
 
-    assert last_checkpoint(temp_dir / "zero_checkpoints") == None
+    assert last_checkpoint(temp_dir / "zero_checkpoints") is None

--- a/tests/torch/test_utils.py
+++ b/tests/torch/test_utils.py
@@ -94,4 +94,4 @@ def test_last_checkpoint(temp_dir):
     time.sleep(0.1)
     _create_file(temp_dir / "zero_checkpoints" / "second" / "not_ckpt")
 
-    assert last_checkpoint(temp_dir / "zero_checkpoints") == "last"
+    assert last_checkpoint(temp_dir / "zero_checkpoints") == None

--- a/thunder/torch/utils.py
+++ b/thunder/torch/utils.py
@@ -112,6 +112,4 @@ def last_checkpoint(root: Union[Path, str]) -> Optional[Union[Path, str]]:
         if p.suffix == ".ckpt":
             checkpoints.append(p)
 
-    if not checkpoints:
-        return "last"
-    return max(checkpoints, key=lambda t: os.stat(t).st_mtime)
+    return max(checkpoints, key=lambda t: os.stat(t).st_mtime, default="last")

--- a/thunder/torch/utils.py
+++ b/thunder/torch/utils.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Union, Optional
+from typing import Any, Optional, Union
 
 import numpy as np
 import torch

--- a/thunder/torch/utils.py
+++ b/thunder/torch/utils.py
@@ -97,13 +97,21 @@ def last_checkpoint(root: Union[Path, str]) -> Union[Path, str]:
     Parameters
     ----------
     root: Union[Path, str]
-        Path to folder, where last.ckpt supposed to be.
+        Path to folder, where last.ckpt or its symbolic link supposed to be.
     Returns
     -------
     checkpoint_path: Union[Path, str]
         If last.ckpt exists - returns Path to it. Otherwise, returns 'last'.
     """
-    checkpoints = [p for p in Path(root).glob("**/*.ckpt") if p.name != "last.ckpt"]
+    checkpoints = []
+    for p in Path(root).rglob('*'):
+        if p.is_symlink():
+            p = p.resolve(strict=False)
+            if p.suffix == '.ckpt':
+                checkpoints.append(p)
+        elif p.suffix == '.ckpt':
+            checkpoints.append(p)
+
     if not checkpoints:
-        return "last"
+        return None
     return max(checkpoints, key=lambda t: os.stat(t).st_mtime)

--- a/thunder/torch/utils.py
+++ b/thunder/torch/utils.py
@@ -106,14 +106,12 @@ def last_checkpoint(root: Union[Path, str]) -> Optional[Union[Path, str]]:
         If last.ckpt exists - returns Path to it. Otherwise, returns 'last'.
     """
     checkpoints = []
-    for p in Path(root).rglob('*'):
+    for p in Path(root).rglob("*"):
         if p.is_symlink():
             p = p.resolve(strict=False)
-            if p.suffix == '.ckpt':
-                checkpoints.append(p)
-        elif p.suffix == '.ckpt':
+        if p.suffix == ".ckpt":
             checkpoints.append(p)
 
     if not checkpoints:
-        return None
+        return "last"
     return max(checkpoints, key=lambda t: os.stat(t).st_mtime)

--- a/thunder/torch/utils.py
+++ b/thunder/torch/utils.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Union, Optional
 
 import numpy as np
 import torch
@@ -84,14 +84,16 @@ def maybe_from_np(*x: Any, device: Union[torch.device, str] = "cpu") -> Any:
     >>> x, y, z = maybe_from_np(x, y, z) # maybe_from_np converts np arrays and tensors and does not affect other types
     >>> dict_of_tensors = to_np(dict_of_np) # maybe_from_np converts any collection
     """
+
     def to_tensor(x):
         if isinstance(x, torch.Tensor):
             return x.to(device)
         return torch.from_numpy(x).to(device)
+
     return squeeze_first(apply_to_collection(x, (np.ndarray, np.generic, torch.Tensor), to_tensor))
 
 
-def last_checkpoint(root: Union[Path, str]) -> Union[Path, str]:
+def last_checkpoint(root: Union[Path, str]) -> Optional[Union[Path, str]]:
     """
     Load most fresh last.ckpt file based on time.
     Parameters


### PR DESCRIPTION
This pull request closes #80 

The problem was there because following symlinks for `pathlib.Path.glob` was [disabled on purpose](https://github.com/python/cpython/issues/70200#issuecomment-1093702406) as a fix for this [issue](https://github.com/python/cpython/issues/70200). Also now in case there is no checkpoints `last_checkpoint` will return `None`.
After these commits it may be needed to edit tests accordingly.