### PR TITLE
Fixing python and torch versions compatibility

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,17 +11,10 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]
-        torch-version: [ '1.13', '2.0.1', '2.5.0', '2.6.0']
+        torch-version: [ '2.0.1', '2.5.0', '2.6.0']
         exclude:
         # In accordance with
         # https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
-          - python-version: '3.11'
-            torch-version: '1.13'
-          - python-version: '3.12'
-            torch-version: '1.13'
-          - python-version: '3.13'
-            torch-version: '1.13'
-
           - python-version: '3.12'
             torch-version: '2.0.1'
           - python-version: '3.13'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
           echo "MODULE_PARENT=$(echo $MODULE_PARENT)" >> $GITHUB_ENV
 
       - name: Adjust NumPy to Pytorch
-        if: ${{ matrix.torch-version }} == '2.1.0'
+        if: ${{ matrix.torch-version }} != '2.1.0'
         run: |
           python -m pip install "numpy<2"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]
         torch-version: [ '1.13', '2.0.1', '2.5.0', '2.6.0']
-#        exclude:
+        exclude:
 #          # python 3.10 supports torch < 2.5
 #          - python-version: '3.10'
 #            torch-version: '2.5.0'
@@ -21,11 +21,11 @@ jobs:
 #            torch-version: '1.13'
 #          - python-version: '3.11'
 #            torch-version: '2.5.0'
-#          # python 3.12 supports torch > 2.0.1
-#          - python-version: '3.12'
-#            torch-version: '1.13'
-#          - python-version: '3.12'
-#            torch-version: '2.0.1'
+          # python 3.12 supports torch >= 2.2.0
+          - python-version: '3.12'
+            torch-version: '1.13'
+          - python-version: '3.12'
+            torch-version: '2.0.1'
 #          # python 3.13 supports torch >= 2.5
 #          - python-version: '3.13'
 #            torch-version: '1.13'
@@ -66,8 +66,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r tests/dev-requirements.txt
-          python -m pip install torch==${{ matrix.torch-version }}
           python -m pip install -e .
+          python -m pip install torch==${{ matrix.torch-version }}
           cd tests
           export MODULE_PARENT=$(python -c "import $MODULE_NAME, os; print(os.path.dirname($MODULE_NAME.__path__[0]))")
           export MODULE_PARENT=${MODULE_PARENT%"/"}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,8 @@ jobs:
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]
         torch-version: [ '1.13', '2.0.1', '2.5.0', '2.6.0']
         exclude:
-        # In accordance with https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
+        # In accordance with
+        # https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
           - python-version: '3.11'
             torch-version: '1.13'
           - python-version: '3.12'
@@ -26,6 +27,7 @@ jobs:
           - python-version: '3.13'
             torch-version: '2.0.1'
 
+          # experimental
           - python-version: '3.13'
             torch-version: '2.5.0'
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -85,8 +85,8 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: reports-${{ matrix.python-version }}
-          path: reports/*-${{ matrix.python-version }}.xml
+          name: reports-${{ matrix.python-version }}-${{ matrix.torch-version }}
+          path: reports/*-${{ matrix.python-version }}-${{ matrix.torch-version }}.xml
 
       - name: Upload coverage results
         uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
           echo "MODULE_PARENT=$(echo $MODULE_PARENT)" >> $GITHUB_ENV
 
       - name: Adjust NumPy to Pytorch
-        if: ${{ matrix.torch-version }} == "2.1.0"
+        if: ${{ matrix.torch-version }} == '2.1.0'
         run: |
           python -m pip install "numpy<2"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
           echo "MODULE_PARENT=$(echo $MODULE_PARENT)" >> $GITHUB_ENV
 
       - name: Adjust NumPy to Pytorch
-        if: ${{ matrix.torch-version }} != '2.1.0'
+        if: matrix.torch-version == '2.1.0'
         run: |
           python -m pip install "numpy<2"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,6 @@ jobs:
           - python-version: '3.13'
             torch-version: '2.0.1'
 
-          # experimental
           - python-version: '3.13'
             torch-version: '2.5.0'
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,7 @@ jobs:
           - python-version: '3.13'
             torch-version: '2.0.1'
 
+          # experimental
           - python-version: '3.13'
             torch-version: '2.5.0'
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]
-        torch-version: [ '2.0.1', '2.5.0', '2.6.0']
+        torch-version: [ '2.1.0', '2.5.0', '2.6.0']
         exclude:
         # In accordance with
         # https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
           - python-version: '3.12'
-            torch-version: '2.0.1'
+            torch-version: '2.1.0'
           - python-version: '3.13'
-            torch-version: '2.0.1'
+            torch-version: '2.1.0'
 
           # experimental
           - python-version: '3.13'
@@ -59,14 +59,19 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r tests/dev-requirements.txt
-          python -m pip install -e .
           python -m pip install torch==${{ matrix.torch-version }}
+          python -m pip install -e .
           cd tests
           export MODULE_PARENT=$(python -c "import $MODULE_NAME, os; print(os.path.dirname($MODULE_NAME.__path__[0]))")
           export MODULE_PARENT=${MODULE_PARENT%"/"}
           cd ..
           echo $MODULE_PARENT
           echo "MODULE_PARENT=$(echo $MODULE_PARENT)" >> $GITHUB_ENV
+
+      - name: Adjust NumPy to Pytorch
+        if: ${{ matrix.torch-version }} == "2.1.0"
+        run: |
+          python -m pip install "numpy<2"
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,24 +13,22 @@ jobs:
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]
         torch-version: [ '1.13', '2.0.1', '2.5.0', '2.6.0']
         exclude:
-#          # python 3.10 supports torch < 2.5
-#          - python-version: '3.10'
-#            torch-version: '2.5.0'
-#          # python 3.11 supports 1.13 < torch < 2.5
-#          - python-version: '3.11'
-#            torch-version: '1.13'
-#          - python-version: '3.11'
-#            torch-version: '2.5.0'
-          # python 3.12 supports torch >= 2.2.0
-          - python-version: '3.12'
+        # In accordance with https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
+          - python-version: '3.11'
             torch-version: '1.13'
           - python-version: '3.12'
+            torch-version: '1.13'
+          - python-version: '3.13'
+            torch-version: '1.13'
+
+          - python-version: '3.12'
             torch-version: '2.0.1'
-#          # python 3.13 supports torch >= 2.5
-#          - python-version: '3.13'
-#            torch-version: '1.13'
-#          - python-version: '3.13'
-#            torch-version: '2.0.1'
+          - python-version: '3.13'
+            torch-version: '2.0.1'
+
+          - python-version: '3.13'
+            torch-version: '2.5.0'
+
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,25 +12,25 @@ jobs:
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]
         torch-version: [ '1.13', '2.0.1', '2.5.0', '2.6.0']
-        exclude:
-          # python 3.10 supports torch < 2.5
-          - python-version: '3.10'
-            torch-version: '2.5.0'
-          # python 3.11 supports 1.13 < torch < 2.5
-          - python-version: '3.11'
-            torch-version: '1.13'
-          - python-version: '3.11'
-            torch-version: '2.5.0'
-          # python 3.12 supports torch > 2.0.1
-          - python-version: '3.12'
-            torch-version: '1.13'
-          - python-version: '3.12'
-            torch-version: '2.0.1'
-          # python 3.13 supports torch >= 2.5
-          - python-version: '3.13'
-            torch-version: '1.13'
-          - python-version: '3.13'
-            torch-version: '2.0.1'
+#        exclude:
+#          # python 3.10 supports torch < 2.5
+#          - python-version: '3.10'
+#            torch-version: '2.5.0'
+#          # python 3.11 supports 1.13 < torch < 2.5
+#          - python-version: '3.11'
+#            torch-version: '1.13'
+#          - python-version: '3.11'
+#            torch-version: '2.5.0'
+#          # python 3.12 supports torch > 2.0.1
+#          - python-version: '3.12'
+#            torch-version: '1.13'
+#          - python-version: '3.12'
+#            torch-version: '2.0.1'
+#          # python 3.13 supports torch >= 2.5
+#          - python-version: '3.13'
+#            torch-version: '1.13'
+#          - python-version: '3.13'
+#            torch-version: '2.0.1'
 
     steps:
       - uses: actions/checkout@v3

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,4 @@
-flake8<=5
+flake8
 flake8-pyproject
 flake8-tidy-imports
 flake8-quotes

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ lazycon>=0.6.3,<1.0.0
 typer>=0.9.0,<1.0.0
 pydantic<3.0.0
 click
-torch
 toolz
 rich
 numpy
@@ -12,5 +11,4 @@ pyyaml
 deli
 joblib
 pytimeparse
-requests
 typing-extensions

--- a/tests/policy/test_lr_scheduler.py
+++ b/tests/policy/test_lr_scheduler.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import numpy as np
 import pytest
 import torch
@@ -206,6 +204,7 @@ def check_scheduler_saving(new_scheduler, scheduler, optim, tmpdir):
 
     # https://pytorch.org/blog/pytorch2-6/
     # in pytorch >= 2.6 `weights_only=True` by default
-    # (previously `False` was teh default)
-    new_scheduler.load_state_dict(torch.load(f"{tmpdir}/scheduler.pth"))
+    # (previously `False` was the default)
+    # TODO: Might be unsafe
+    new_scheduler.load_state_dict(torch.load(f"{tmpdir}/scheduler.pth", weights_only=False))
     assert new_scheduler.state_dict() == scheduler.state_dict()

--- a/thunder/callbacks/metric_monitor.py
+++ b/thunder/callbacks/metric_monitor.py
@@ -171,7 +171,8 @@ class MetricMonitor(Callback):
             dataloader_idx: int = 0,
     ) -> None:
         if len(outputs) != 2:
-            raise ValueError(f"Expected step output in form of 2 elements (x, y)," f"but received {len(outputs)}")
+            raise ValueError(f"Expected step output in form of 2 elements (x, y), "
+                             f"but received {len(outputs)}")
         xs, ys = outputs
         xs = _recombine_batch(xs) if isinstance(xs, (list, tuple)) else xs
         ys = _recombine_batch(ys) if isinstance(ys, (list, tuple)) else ys

--- a/thunder/policy.py
+++ b/thunder/policy.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, Dict, List, Union
 from more_itertools import zip_equal
 from toolz import juxt
 from torch.optim import Optimizer
-
 from torch.optim.lr_scheduler import LRScheduler
 
 

--- a/thunder/policy.py
+++ b/thunder/policy.py
@@ -8,11 +8,7 @@ from more_itertools import zip_equal
 from toolz import juxt
 from torch.optim import Optimizer
 
-
-try:
-    from torch.optim.lr_scheduler import LRScheduler
-except ImportError:
-    from torch.optim.lr_scheduler import _LRScheduler as LRScheduler
+from torch.optim.lr_scheduler import LRScheduler
 
 
 class Policy(LRScheduler, metaclass=ABCMeta):

--- a/thunder/policy.py
+++ b/thunder/policy.py
@@ -53,19 +53,7 @@ class Policy(LRScheduler, metaclass=ABCMeta):
         -------
         Dict[str, Any]
         """
-        keys = (*keys, "optimizer")
-        return {key: value for key, value in self.__dict__.items() if key not in keys}
-
-    @abstractmethod
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
-        """
-        Loads state dict of scheduler
-        Parameters
-        ----------
-        state_dict: Dict[str, Any]
-            State dict of scheduler.
-        """
-        self.__dict__.update(state_dict)
+        return {key: value for key, value in super().state_dict().items() if key not in keys}
 
 
 class MappingPolicy(Policy, metaclass=ABCMeta):


### PR DESCRIPTION
Now only python >= 3.10 is supported. Tests are run only for torch >= 2.1 