### PR TITLE
py3.14

### DIFF
--- a/.github/workflows/check-version.yaml
+++ b/.github/workflows/check-version.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - run: git fetch origin gh-pages --depth=1
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Install
         run: |
           pip install -e .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Check code style
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - id: get_version
         name: Get the release version

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.12', '3.13' ]
+        python-version: [ '3.12', '3.13', '3.14' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,13 @@ jobs:
         # https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
         python-version: [ '3.12', '3.13', '3.14' ]
         torch-version: [ '2.6.0', '2.7.0', '2.8.0', '2.9.0' ]
+        exclude:
+          - python-version: '3.14'
+            torch-version: '2.6.0'
+          - python-version: '3.14'
+            torch-version: '2.7.0'
+          - python-version: '3.14'
+            torch-version: '2.8.0'
 
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         # In accordance with
         # https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
-        python-version: [ '3.12', '3.13' ]
-        torch-version: [ '2.6.0', '2.7.0', '2.8.0']
+        python-version: [ '3.12', '3.13', '3.14' ]
+        torch-version: [ '2.6.0', '2.7.0', '2.8.0', '2.9.0' ]
 
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Programming Language :: Python :: 3 :: Only',
 ]
 


### PR DESCRIPTION
Ci now supports tests for python 3.12-3.14 and torch 2.6-2.9. All the docs and releases are build using python 3.13